### PR TITLE
Added nord.colors.gray to colorscheme

### DIFF
--- a/lua/nord/colors.lua
+++ b/lua/nord/colors.lua
@@ -32,6 +32,8 @@ local nord = {
 	disabled =      '#3B4252',
 	cursor =        '#E5E9F0',
 	accent =        '#D8DEE9',
+        gray =          '#4C566A',
+
 
 	error =         '#BF616A',
 	link =          '#A3BE8C',


### PR DESCRIPTION
You seemed to call nord.colors.gray in a few places in nord.theme which wasn't set previously (returned `nil`). This PR adds nord.gray with the same value as nord3_gui