### PR TITLE
Fix issue where lualine is not showing some sections

### DIFF
--- a/lua/lualine/themes/nord.lua
+++ b/lua/lualine/themes/nord.lua
@@ -4,28 +4,28 @@ local nord = {}
 
 nord.normal = {
 	a = {fg = colors.nord0_gui, bg = colors.nord4_gui, gui = 'bold'},
-	b = {fg = colors.nord10_gui, bg = colors.nord10_gui},
+	b = {fg = colors.nord4_gui, bg = colors.nord10_gui},
 	c = {fg = colors.nord4_gui, bg = colors.nord1_gui},
 }
 
 nord.insert = {
 	a = {fg = colors.nord0_gui, bg = colors.nord14_gui, gui = 'bold'},
-	b = {fg = colors.nord10_gui, bg = colors.nord10_gui},
+	b = {fg = colors.nord4_gui, bg = colors.nord10_gui},
 }
 
 nord.visual = {
 	a = {fg = colors.nord0_gui, bg = colors.nord9_gui, gui = 'bold'},
-	b = {fg = colors.nord10_gui, bg = colors.nord10_gui},
+	b = {fg = colors.nord4_gui, bg = colors.nord10_gui},
 }
 
 nord.replace = {
 	a = {fg = colors.nord0_gui, bg = colors.nord11_gui, gui = 'bold'},
-	b = {fg = colors.nord10_gui, bg = colors.nord10_gui},
+	b = {fg = colors.nord4_gui, bg = colors.nord10_gui},
 }
 
 nord.command = {
 	a = {fg = colors.nord0_gui, bg = colors.nord15_gui, gui = 'bold'},
-	b = {fg = colors.nord10_gui, bg = colors.nord10_gui},
+	b = {fg = colors.nord4_gui, bg = colors.nord10_gui},
 }
 
 nord.innord10_gui = {


### PR DESCRIPTION
Using `lualine`, sometimes the foreground color and the background color are the same, leading to some unreadable text.

For example:
![image](https://user-images.githubusercontent.com/59405008/128465689-dcd65db7-a3c8-49d9-aac9-0eccdaa0acfe.png)

The progress section is not visible.

With the pull request applied:
![image](https://user-images.githubusercontent.com/59405008/128465855-d3f6c13a-bdb8-4419-ae49-00df25bc5e7e.png)
