### PR TITLE
Changed color for escape characters in strings.

### DIFF
--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -223,7 +223,7 @@ theme.loadTreeSitter = function ()
     TSPunctBracket =      { fg = nord.nord8_gui }, -- For brackets and parens.
     TSPunctSpecial =      { fg = nord.nord8_gui }, -- For special punctutation that does not fall in the catagories before.
     TSStringRegex =       { fg = nord.nord7_gui }, -- For regexes.
-    TSStringEscape =      { fg = nord.nord1_gui }, -- For escape characters within a string.
+    TSStringEscape =      { fg = nord.nord15_gui }, -- For escape characters within a string.
     TSSymbol =            { fg = nord.nord15_gui },    -- For identifiers referring to symbols or atoms.
     TSType =              { fg = nord.nord9_gui},    -- For types.
     TSTypeBuiltin =       { fg = nord.nord9_gui},    -- For builtin types.


### PR DESCRIPTION
Before: ![before](https://user-images.githubusercontent.com/50531499/132561691-bf63758c-77c6-4095-a06c-58428679dc3b.png)
Escape characters are really hard to see. Especially, when the cursorline has the same color.

After: ![after](https://user-images.githubusercontent.com/50531499/132561824-4c0236a5-74e3-43fa-b931-a6d55671f105.png)

