### PR TITLE
lightspeed.nvim: Updated docs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ added to NeoVim like built-in LSP and [TreeSitter](https://github.com/nvim-trees
     + [Lualine](https://github.com/hoob3rt/lualine.nvim)
     + [Neogit](https://github.com/TimUntersberger/neogit)
     + [vim-sneak](https://github.com/justinmk/vim-sneak)
+    + [lightspeed.nvim](https://github.com/ggandor/lightspeed.nvim)
 
 + Ability to change background on sidebar-like windows like Nvim-Tree, Packer, terminal etc.
 

--- a/doc/nord.txt
+++ b/doc/nord.txt
@@ -37,6 +37,7 @@ CONTENTS
                                         -Vim-Sneak
                                         -Nvim-Dap
                                         -Vim-Illuminate
+                                        -lightspeed.nvim
 
     + Ability to have a different background on sidebar windows like Nvim-Tree,
       Terminal, Packer, Whichkey, QuickFix etc.


### PR DESCRIPTION
Added lightspeed.nvim to the supported plugins in the readme and the docs. I forgot to add it in #46.