### PR TITLE
Highlight CmpItemAbbrMatchFuzzy

### DIFF
--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -413,6 +413,7 @@ theme.loadPlugins = function()
     -- Cmp
     CmpItemKind =	{ fg = nord.nord15_gui },
     CmpItemAbbrMatch =	{ fg = nord.nord5_gui, style = 'bold' },
+    CmpItemAbbrMatchFuzzy = { fg = nord.nord5_gui, style = 'bold' },
     CmpItemAbbr =	{ fg = nord.nord4_gui},
     CmpItemMenu =       { fg = nord.nord14_gui },
 		


### PR DESCRIPTION
Add highlighting to `CmpItemAbbrMatchFuzzy` using the same styling as `CmpItemAbbrMatch`

<img width="211" alt="Screen Shot 2021-10-27 at 12 19 46 PM" src="https://user-images.githubusercontent.com/2405957/139106309-d141adf8-b90f-4a4f-9449-ac0dcf5ef96f.png">
