### PR TITLE
Don't override TelescopeNormal highlight

### DIFF
--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -357,7 +357,6 @@ theme.loadPlugins = function()
     TelescopeSelectionCaret = { fg = nord.nord9_gui },
     TelescopeSelection =      { fg = nord.nord9_gui },
     TelescopeMatching =       { fg = nord.nord8_gui },
-    TelescopeNormal =         { fg = nord.nord4_gui, bg = nord.float },
 
     -- NvimTree
     NvimTreeRootFolder =        { fg = nord.nord7_gui, style = "bold" },


### PR DESCRIPTION
Overriding this highlight causes some Telescope floating windows to not
respect the `nord_disable_background` setting.

---

This should resolve https://github.com/shaunsingh/nord.nvim/issues/62. I tested it with `nord_disable_background` on/off and the highlighting looks correct for me.