### PR TITLE
Introduce barbar.nvim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ added to NeoVim like built-in LSP and [TreeSitter](https://github.com/nvim-trees
     + [Neogit](https://github.com/TimUntersberger/neogit)
     + [vim-sneak](https://github.com/justinmk/vim-sneak)
     + [lightspeed.nvim](https://github.com/ggandor/lightspeed.nvim)
+    + [barbar.nvim](https://github.com/romgrk/barbar.nvim)
 
 + Ability to change background on sidebar-like windows like Nvim-Tree, Packer, terminal etc.
 

--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -146,6 +146,30 @@ theme.loadEditor = function()
 		-- BufferLine
 		BufferLineIndicatorSelected = { fg = nord.nord0_gui },
 		BufferLineFill = { bg = nord.nord0_gui },
+		
+		-- Barbar
+		BufferTabpageFill = { bg = nord.nord0_gui },
+
+		BufferCurrent = { bg = nord.nord1_gui },
+		BufferCurrentMod = { bg = nord.nord1_gui, fg = nord.nord15_gui },
+		BufferCurrentIcon = { bg = nord.nord1_gui },
+		BufferCurrentSign = { bg = nord.nord1_gui },
+		BufferCurrentIndex = { bg = nord.nord1_gui },
+		BufferCurrentTarget = { bg = nord.nord1_gui, fg = nord.nord11_gui },
+
+		BufferInactive = { bg = nord.nord0_gui, fg = nord.nord3_gui },
+		BufferInactiveMod = { bg = nord.nord0_gui, fg = nord.nord15_gui },
+		BufferInactiveIcon = { bg = nord.nord0_gui , fg = nord.nord3_gui },
+		BufferInactiveSign = { bg = nord.nord0_gui , fg = nord.nord3_gui },
+		BufferInactiveIndex = { bg = nord.nord0_gui , fg = nord.nord3_gui },
+		BufferInactiveTarget = { bg = nord.nord0_gui, fg = nord.nord11_gui },
+
+		BufferVisible = { bg = nord.nord2_gui },
+		BufferVisibleMod = { bg = nord.nord2_gui, fg = nord.nord15_gui },
+		BufferVisibleIcon = { bg = nord.nord2_gui },
+		BufferVisibleSign = { bg = nord.nord2_gui },
+		BufferVisibleIndex = { bg = nord.nord2_gui },
+		BufferVisibleTarget = { bg = nord.nord2_gui, fg = nord.nord11_gui },
 	}
 
 	-- Options:


### PR DESCRIPTION
Hi, I've tried to make somethink like in the screenshot in the README but I'm not sure that the final rendering looks like when you use bufferline.
It looks like that : 
![2022-05-11-144023_545x66_scrot](https://user-images.githubusercontent.com/3751019/167852354-2db22c6f-5301-400a-9f07-d3655b6e05f9.png)

My config : 
```lua
  vim.g.bufferline = {
    icons = "both",
    icon_separator_active = " ",
    icon_separator_inactive = " ",
    icon_close_tab = "",
    icon_close_tab_modified = "●",
    icon_pinned = "車",
  }
```  