### PR TITLE
Lualine theme improvments

### DIFF
--- a/lua/lualine/themes/nord.lua
+++ b/lua/lualine/themes/nord.lua
@@ -15,7 +15,7 @@ nord.insert = {
 }
 
 nord.visual = {
-	a = { fg = colors.nord0_gui, bg = colors.nord9_gui },
+	a = { fg = colors.nord0_gui, bg = colors.nord7_gui },
 	b = { fg = colors.nord4_gui, bg = colors.nord2_gui },
 	y = {  fg = colors.nord5_gui, bg = colors.nord2_gui },
 }

--- a/lua/lualine/themes/nord.lua
+++ b/lua/lualine/themes/nord.lua
@@ -10,25 +10,25 @@ nord.normal = {
 
 nord.insert = {
 	a = { fg = colors.nord1_gui, bg = colors.nord4_gui },
-	b = { fg = colors.nord6_gui, bg = colors.nord3_gui_bright },
+	b = { fg = colors.nord6_gui, bg = colors.nord2_gui },
 	y = {  fg = colors.nord5_gui, bg = colors.nord2_gui },
 }
 
 nord.visual = {
 	a = { fg = colors.nord0_gui, bg = colors.nord9_gui },
-	b = { fg = colors.nord4_gui, bg = colors.nord10_gui },
+	b = { fg = colors.nord4_gui, bg = colors.nord2_gui },
 	y = {  fg = colors.nord5_gui, bg = colors.nord2_gui },
 }
 
 nord.replace = {
 	a = { fg = colors.nord0_gui, bg = colors.nord11_gui },
-	b = { fg = colors.nord4_gui, bg = colors.nord10_gui },
+	b = { fg = colors.nord4_gui, bg = colors.nord2_gui },
 	y = {  fg = colors.nord5_gui, bg = colors.nord2_gui },
 }
 
 nord.command = {
 	a = { fg = colors.nord0_gui, bg = colors.nord15_gui, gui = "bold" },
-	b = { fg = colors.nord4_gui, bg = colors.nord10_gui },
+	b = { fg = colors.nord4_gui, bg = colors.nord2_gui },
 	y = {  fg = colors.nord5_gui, bg = colors.nord2_gui },
 }
 


### PR DESCRIPTION
With this PR, the background color of the `b` section of lualine will not change any more when changing mode. I think it's visualy annoying (and it is not happening with https://github.com/arcticicestudio/nord-vim).

![2022-05-19-090629_286x164_scrot](https://user-images.githubusercontent.com/3751019/169231504-c77e8def-33f1-46e7-9023-01ce03c1e690.png)
![2022-05-19-090613_300x121_scrot](https://user-images.githubusercontent.com/3751019/169231507-0b2cf497-b7e6-4806-bb5d-eacbcf718c03.png)

I also set a different color for visual mode (the same color as the original theme https://github.com/arcticicestudio/nord-vim) because I feel confused to have the same color than Normal mode.

![2022-05-19-090713_201x99_scrot](https://user-images.githubusercontent.com/3751019/169231501-34d097d3-5070-4c9a-8bfc-b01219332c91.png)


