### PR TITLE
fix: cannot see GitSigns current line blame when course line isn't tr…

### DIFF
--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -426,6 +426,7 @@ theme.loadPlugins = function()
 		GitSignsDelete = { fg = nord.nord11_gui }, -- diff mode: Deleted line |diff.txt|
 		GitSignsDeleteNr = { fg = nord.nord11_gui }, -- diff mode: Deleted line |diff.txt|
 		GitSignsDeleteLn = { fg = nord.nord11_gui }, -- diff mode: Deleted line |diff.txt|
+        GitSignsCurrentLineBlame = { fg = nord.nord3_gui_bright, style = "bold" },
 
 		-- Telescope
 		TelescopePromptBorder = { fg = nord.nord8_gui },


### PR DESCRIPTION
I find that I cannot see GitSigns current line blame because the colour of blames and course line highlight is identical so I changed the colour of current line blame.