### PR TITLE
Add explicit support for 'mini.nvim'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ added to NeoVim like built-in LSP and [TreeSitter](https://github.com/nvim-trees
     + [barbar.nvim](https://github.com/romgrk/barbar.nvim)
     + [nvim-notify](https://github.com/rcarriga/nvim-notify)
     + [leap.nvim](https://github.com/ggandor/leap.nvim)
+    + [mini.nvim](https://github.com/echasnovski/mini.nvim)
 
 + Ability to change background on sidebar-like windows like Nvim-Tree, Packer, terminal etc.
 

--- a/doc/nord.txt
+++ b/doc/nord.txt
@@ -38,6 +38,7 @@ CONTENTS
                                         -Nvim-Dap
                                         -Vim-Illuminate
                                         -lightspeed.nvim
+                                        -mini.nvim
 
     + Ability to have a different background on sidebar windows like Nvim-Tree,
       Terminal, Packer, Whichkey, QuickFix etc.

--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -564,6 +564,57 @@ theme.loadPlugins = function()
 		-- Statusline
 		StatusLineDull = { fg = nord.nord3_gui, bg = nord.nord1_gui },
 		StatusLineAccent = { fg = nord.nord0_gui, bg = nord.nord13_gui },
+
+		-- mini.nvim
+		MiniCompletionActiveParameter = { style = "underline" },
+
+		MiniCursorword = { bg = nord.nord3_gui },
+		MiniCursorwordCurrent = { bg = nord.nord3_gui },
+
+		MiniIndentscopeSymbol = { fg = nord.nord10_gui },
+		MiniIndentscopePrefix = { style = "nocombine" }, -- Make it invisible
+
+		MiniJump = { fg = nord.nord0_gui, bg = nord.nord4_gui },
+
+		MiniJump2dSpot = { fg = nord.nord12_gui, style = "bold,nocombine" },
+
+		MiniStarterCurrent = { style = "nocombine" },
+		MiniStarterFooter = { fg = nord.nord14_gui, style = "italic" },
+		MiniStarterHeader = { fg = nord.nord9_gui },
+		MiniStarterInactive = { link = "Comment" },
+		MiniStarterItem = { link = "Normal" },
+		MiniStarterItemBullet = { fg = nord.nord4_gui },
+		MiniStarterItemPrefix = { fg = nord.nord15_gui },
+		MiniStarterSection = { fg = nord.nord4_gui },
+		MiniStarterQuery = { fg = nord.nord10_gui },
+
+		MiniStatuslineDevinfo = { fg = nord.nord4_gui, bg = nord.nord2_gui },
+		MiniStatuslineFileinfo = { fg = nord.nord4_gui, bg = nord.nord2_gui },
+		MiniStatuslineFilename = { fg = nord.nord4_gui, bg = nord.nord1_gui },
+		MiniStatuslineInactive = { fg = nord.nord4_gui, bg = nord.nord0_gui, style = "bold" },
+		MiniStatuslineModeCommand = { fg = nord.nord0_gui, bg = nord.nord15_gui, style = "bold" },
+		MiniStatuslineModeInsert = { fg = nord.nord1_gui, bg = nord.nord4_gui, style = "bold" },
+		MiniStatuslineModeNormal = { fg = nord.nord1_gui, bg = nord.nord9_gui, style = "bold" },
+		MiniStatuslineModeOther = { fg = nord.nord0_gui, bg = nord.nord13_gui, style = "bold" },
+		MiniStatuslineModeReplace = { fg = nord.nord0_gui, bg = nord.nord11_gui, style = "bold" },
+		MiniStatuslineModeVisual = { fg = nord.nord0_gui, bg = nord.nord7_gui, style = "bold" },
+
+		MiniSurround = { link = "IncSearch" },
+
+		MiniTablineCurrent = { bg = nord.nord1_gui },
+		MiniTablineFill = { link = "TabLineFill" },
+		MiniTablineHidden = { bg = nord.nord0_gui, fg = nord.nord3_gui },
+		MiniTablineModifiedCurrent = { bg = nord.nord1_gui, fg = nord.nord15_gui },
+		MiniTablineModifiedHidden = { bg = nord.nord0_gui, fg = nord.nord15_gui },
+		MiniTablineModifiedVisible = { bg = nord.nord2_gui, fg = nord.nord15_gui },
+		MiniTablineTabpagesection = { fg = nord.nord10_gui, bg = nord.nord6_gui, style = "reverse,bold" },
+		MiniTablineVisible = { bg = nord.nord2_gui },
+
+		MiniTestEmphasis = { style = "bold" },
+		MiniTestFail = { fg = nord.nord11_gui, style = "bold" },
+		MiniTestPass = { fg = nord.nord14_gui, style = "bold" },
+
+		MiniTrailspace = { bg = nord.nord11_gui },
 	}
 	-- Options:
 


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Basic choices are taken from highlight groups to which 'mini.nvim' makes links by default or from analogous plugins.

Differences from default linked groups:
- 'mini.cursorword' is based on 'Illuminate'.
- 'mini.indentscope' is based on 'Indent Blankline'.
- 'mini.jump' is based on 'Sneak'.
- 'mini.jump2d' is chosen to be visually distinctive. Using `nocombine` to be consistent (not have italic labels on italic text).
- 'mini.starter' is based on 'Dashboard' and personal choices:
    - `MiniStarterItemBullet` is as border.
    - `MiniStarterItemPrefix` and `MiniStarterQuery` are based on "warning" and "info" diagnostic colors to be opposite of each other.
    - `MiniStarterSection` is chosen to be visible (as from "Special" highlight group).
- 'mini.statusline' is based on 'lualine/themes/nord.lua' and personal choices:
    - `MiniStatuslineDevinfo` and `MiniStatuslineFileinfo` are "slightly different text".
    - All `MiniStatuslineMode*` have bold text to be visually distinctive.
    - `MiniStatuslineModeOther` is chosen to be different from others.
- 'mini.tabline' is based on 'Barbar':
    - `MiniTablineTabpagesection` is as "Search" but with bold text for visibility.
- 'mini.test' has red for fail and green for pass.
- 'mini.trailspace' has group with red background to draw attention.

Before:

https://user-images.githubusercontent.com/24854248/177985502-004a8c9c-cf97-4c8a-b8d3-e46dd5280e39.mp4

After:

https://user-images.githubusercontent.com/24854248/177985520-c5a5b196-eeed-4a5e-b048-822619c0f9a6.mp4