### PR TITLE
Uniform diff background colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,15 @@ require('lualine').setup {
 | nord_cursorline_transparent     | `false`     | Set the cursorline transparent/visible
 | nord_enable_sidebar_background  | `false`     | Re-enables the background of the sidebar if you disabled the background of everything
 | nord_italic                     | `true`      | enables/disables italics
+| nord_uniform_diff_background    | `false`     | enables/disables colorful backgrounds when used in *diff* mode
  
-
 ```lua
 -- Example config in lua
 vim.g.nord_contrast = true
 vim.g.nord_borders = false
 vim.g.nord_disable_background = false
 vim.g.nord_italic = false
+vim.g.nord_uniform_diff_background = true
 
 -- Load the colorscheme
 require('nord').set()
@@ -108,6 +109,7 @@ let g:nord_contrast = v:true
 let g:nord_borders = v:false
 let g:nord_disable_background = v:false
 let g:nord_italic = v:false
+let g:nord_uniform_diff_background = v:true
 
 " Load the colorscheme
 colorscheme nord

--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -82,10 +82,6 @@ theme.loadEditor = function()
 		Cursor = { fg = nord.nord4_gui, bg = nord.none, style = "reverse" }, -- the character under the cursor
 		CursorIM = { fg = nord.nord5_gui, bg = nord.none, style = "reverse" }, -- like Cursor, but used when in IME mode
 		Directory = { fg = nord.nord7_gui, bg = nord.none }, -- directory names (and other special names in listings)
-		DiffAdd = { fg = nord.nord14_gui, bg = nord.none, style = "reverse" }, -- diff mode: Added line
-		DiffChange = { fg = nord.nord13_gui, bg = nord.none, style = "reverse" }, --  diff mode: Changed line
-		DiffDelete = { fg = nord.nord11_gui, bg = nord.none, style = "reverse" }, -- diff mode: Deleted line
-		DiffText = { fg = nord.nord15_gui, bg = nord.none, style = "reverse" }, -- diff mode: Changed text within a changed line
 		EndOfBuffer = { fg = nord.nord1_gui },
 		ErrorMsg = { fg = nord.none },
 		Folded = { fg = nord.nord3_gui_bright, bg = nord.none, style = "italic" },
@@ -210,6 +206,18 @@ theme.loadEditor = function()
 		editor.VertSplit = { fg = nord.nord2_gui }
 	else
 		editor.VertSplit = { fg = nord.nord0_gui }
+	end
+
+	if vim.g.nord_uniform_diff_background then
+		editor.DiffAdd = { fg = nord.nord14_gui, bg = nord.nord1_gui } -- diff mode: Added line
+		editor.DiffChange = { fg = nord.nord13_gui, bg = nord.nord1_gui } --  diff mode: Changed line
+		editor.DiffDelete = { fg = nord.nord11_gui, bg = nord.nord1_gui } -- diff mode: Deleted line
+		editor.DiffText = { fg = nord.nord15_gui, bg = nord.nord1_gui } -- diff mode: Changed text within a changed line
+	else
+		editor.DiffAdd = { fg = nord.nord14_gui, bg = nord.none, style = "reverse" } -- diff mode: Added line
+		editor.DiffChange = { fg = nord.nord13_gui, bg = nord.none, style = "reverse" } --  diff mode: Changed line
+		editor.DiffDelete = { fg = nord.nord11_gui, bg = nord.none, style = "reverse" } -- diff mode: Deleted line
+		editor.DiffText = { fg = nord.nord15_gui, bg = nord.none, style = "reverse" } -- diff mode: Changed text within a changed line
 	end
 
 	return editor


### PR DESCRIPTION
Hi 👋 

Thanks for the great work with the plugin!

An option I used to make use of before swapping from [arcticicestudio/nord-vim](https://github.com/arcticicestudio/nord-vim) was the option `nord_uniform_diff_background`, as introduced in this PR - https://github.com/arcticicestudio/nord-vim/pull/61

This is basically a copy of that PR