### PR TITLE
yaml: Adjust filetype-specific highlights

### DIFF
--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -337,6 +337,23 @@ theme.loadTreeSitter = function()
 	return treesitter
 end
 
+theme.loadFiletypes = function()
+	-- Filetype-specific highlight groups
+
+	local ft = {
+		-- yaml
+		yamlBlockMappingKey = { fg = nord.nord7_gui },
+		yamlBool = { link = "Boolean" },
+		yamlDocumentStart = { link = "Keyword" },
+		yamlTSField = { fg = nord.nord7_gui },
+		yamlTSString = { fg = nord.nord4_gui },
+		yamlTSPunctSpecial = { link = "Keyword" },
+		yamlKey = { fg = nord.nord7_gui }, -- stephpy/vim-yaml
+	}
+
+	return ft
+end
+
 theme.loadLSP = function()
 	-- Lsp highlight groups
 

--- a/lua/nord/util.lua
+++ b/lua/nord/util.lua
@@ -55,6 +55,7 @@ function util.load()
 	local editor = nord.loadEditor()
 	local syntax = nord.loadSyntax()
 	local treesitter = nord.loadTreeSitter()
+	local filetypes = nord.loadFiletypes()
 
 	-- load editor highlights
 	util.loadColorSet(editor)
@@ -64,6 +65,9 @@ function util.load()
 
 	-- load treesitter highlights
 	util.loadColorSet(treesitter)
+
+	-- load filetype-specific highlights
+	util.loadColorSet(filetypes)
 
 	nord.loadTerminal()
 


### PR DESCRIPTION
Fixes #104

Treesitter highlighting

<img width="831" alt="Screenshot 2022-08-13 at 16 23 58" src="https://user-images.githubusercontent.com/3299086/184498453-f55dfb94-3486-4890-a2a2-d15f9871980b.png">

Vim highlighting

<img width="786" alt="image" src="https://user-images.githubusercontent.com/3299086/184498675-be7e87a2-47f6-4045-8f94-c21b3c1a4979.png">