### PR TITLE
Respect nord_italic / nord_bold consistently.

### DIFF
--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -2,9 +2,23 @@ local nord = require("nord.colors")
 
 local theme = {}
 
+local italic = vim.g.nord_italic == false and nord.none or "italic"
+local italic_undercurl = vim.g.nord_italic == false and "undercurl" or "italic,undercurl"
+local bold = vim.g.nord_bold == false and nord.none or "bold"
+local reverse_bold = vim.g.nord_bold == false and "reverse" or "reverse,bold"
+local bold_underline = vim.g.nord_bold == false and "underline" or "bold,underline"
+local bold_italic;
+if vim.g.nord_bold == false then
+	bold_italic = vim.g.nord_italic == false and nord.none or "italic"
+elseif vim.g.nord_italic == false then
+	bold_italic = "bold"
+else
+	bold_italic = "bold,italic"
+end
+
 theme.loadSyntax = function()
 	-- Syntax highlight groups
-	local syntax = {
+	return {
 		Type = { fg = nord.nord9_gui }, -- int, long, char, etc.
 		StorageClass = { fg = nord.nord9_gui }, -- static, register, volatile, etc.
 		Structure = { fg = nord.nord9_gui }, -- struct, union, enum, etc.
@@ -31,57 +45,29 @@ theme.loadSyntax = function()
 		Debug = { fg = nord.nord11_gui }, -- debugging statements
 		Underlined = { fg = nord.nord14_gui, bg = nord.none, style = "underline" }, -- text that stands out, HTML links
 		Ignore = { fg = nord.nord1_gui }, -- left blank, hidden
-		Todo = { fg = nord.nord13_gui, bg = nord.none, style = "bold,italic" }, -- anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+		Todo = { fg = nord.nord13_gui, bg = nord.none, style = bold_italic }, -- anything that needs extra attention; mostly the keywords TODO FIXME and XXX
 		Conceal = { fg = nord.none, bg = nord.nord0_gui },
 		htmlLink = { fg = nord.nord14_gui, style = "underline" },
 		markdownH1Delimiter = { fg = nord.nord8_gui },
 		markdownH2Delimiter = { fg = nord.nord11_gui },
 		markdownH3Delimiter = { fg = nord.nord14_gui },
+		htmlH1 = { fg = nord.nord8_gui, style = bold },
+		htmlH2 = { fg = nord.nord11_gui, style = bold },
+		htmlH3 = { fg = nord.nord14_gui, style = bold },
+		htmlH4 = { fg = nord.nord15_gui, style = bold },
+		htmlH5 = { fg = nord.nord9_gui, style = bold },
+		markdownH1 = { fg = nord.nord8_gui, style = bold },
+		markdownH2 = { fg = nord.nord11_gui, style = bold },
+		markdownH3 = { fg = nord.nord14_gui, style = bold },
+		Error = { fg = nord.nord11_gui, bg = nord.none, style = bold_underline }, -- any erroneous construct with bold
+		Comment = { fg = nord.nord3_gui_bright, style = italic }, -- italic comments
+		Conditional = { fg = nord.nord9_gui, style = italic }, -- italic if, then, else, endif, switch, etc.
+		Function = { fg = nord.nord8_gui, style = italic }, -- italic funtion names
+		Identifier = { fg = nord.nord9_gui, style = italic }, -- any variable name
+		Keyword = { fg = nord.nord9_gui, style = italic }, -- italic for, do, while, etc.
+		Repeat = { fg = nord.nord9_gui, style = italic }, -- italic any other keyword
+		String = { fg = nord.nord14_gui, style = italic }, -- any string
 	}
-
-  -- Bold highlights --
-  if vim.g.nord_bold == false then
-		syntax.htmlH1 = { fg = nord.nord8_gui }
-		syntax.htmlH2 = { fg = nord.nord11_gui }
-		syntax.htmlH3 = { fg = nord.nord14_gui }
-		syntax.htmlH4 = { fg = nord.nord15_gui }
-		syntax.htmlH5 = { fg = nord.nord9_gui }
-		syntax.markdownH1 = { fg = nord.nord8_gui }
-		syntax.markdownH2 = { fg = nord.nord11_gui }
-		syntax.markdownH3 = { fg = nord.nord14_gui }
-		syntax.Error = { fg = nord.nord11_gui, bg = nord.none, style = "underline" } -- any erroneous construct without bold
-  else
-		syntax.htmlH1 = { fg = nord.nord8_gui, style = "bold" }
-		syntax.htmlH2 = { fg = nord.nord11_gui, style = "bold" }
-		syntax.htmlH3 = { fg = nord.nord14_gui, style = "bold" }
-		syntax.htmlH4 = { fg = nord.nord15_gui, style = "bold" }
-		syntax.htmlH5 = { fg = nord.nord9_gui, style = "bold" }
-		syntax.markdownH1 = { fg = nord.nord8_gui, style = "bold" }
-		syntax.markdownH2 = { fg = nord.nord11_gui, style = "bold" }
-		syntax.markdownH3 = { fg = nord.nord14_gui, style = "bold" }
-		syntax.Error = { fg = nord.nord11_gui, bg = nord.none, style = "bold,underline" } -- any erroneous construct with bold
-  end
-
-	-- Italic comments
-	if vim.g.nord_italic == false then
-		syntax.Comment = { fg = nord.nord3_gui_bright } -- normal comments
-		syntax.Conditional = { fg = nord.nord9_gui } -- normal if, then, else, endif, switch, etc.
-		syntax.Function = { fg = nord.nord8_gui } -- normal function names
-		syntax.Identifier = { fg = nord.nord9_gui } -- any variable name
-		syntax.Keyword = { fg = nord.nord9_gui } -- normal for, do, while, etc.
-		syntax.Repeat = { fg = nord.nord9_gui } -- normal any other keyword
-		syntax.String = { fg = nord.nord14_gui } -- any string
-	else
-		syntax.Comment = { fg = nord.nord3_gui_bright, bg = nord.none, style = "italic" } -- italic comments
-		syntax.Conditional = { fg = nord.nord9_gui, bg = nord.none, style = "italic" } -- italic if, then, else, endif, switch, etc.
-		syntax.Function = { fg = nord.nord8_gui, bg = nord.none, style = "italic" } -- italic funtion names
-		syntax.Identifier = { fg = nord.nord9_gui, bg = nord.none, style = "italic" } -- any variable name
-		syntax.Keyword = { fg = nord.nord9_gui, bg = nord.none, style = "italic" } -- italic for, do, while, etc.
-		syntax.Repeat = { fg = nord.nord9_gui, bg = nord.none, style = "italic" } -- italic any other keyword
-		syntax.String = { fg = nord.nord14_gui, bg = nord.none, style = "italic" } -- any string
-	end
-
-	return syntax
 end
 
 theme.loadEditor = function()
@@ -90,19 +76,19 @@ theme.loadEditor = function()
 	local editor = {
 		NormalFloat = { fg = nord.nord4_gui, bg = nord.float }, -- normal text and background color
 		FloatBorder = { fg = nord.nord4_gui, bg = nord.float }, -- normal text and background color
-		ColorColumn = { fg = nord.none, bg = nord.nord1_gui }, --  used for the columns set with 'colorcolumn'
+		ColorColumn = { fg = nord.none, bg = nord.nord1_gui }, -- used for the columns set with 'colorcolumn'
 		Conceal = { fg = nord.nord1_gui }, -- placeholder characters substituted for concealed text (see 'conceallevel')
 		Cursor = { fg = nord.nord4_gui, bg = nord.none, style = "reverse" }, -- the character under the cursor
 		CursorIM = { fg = nord.nord5_gui, bg = nord.none, style = "reverse" }, -- like Cursor, but used when in IME mode
 		Directory = { fg = nord.nord7_gui, bg = nord.none }, -- directory names (and other special names in listings)
 		EndOfBuffer = { fg = nord.nord1_gui },
 		ErrorMsg = { fg = nord.none },
-		Folded = { fg = nord.nord3_gui_bright, bg = nord.none, style = "italic" },
+		Folded = { fg = nord.nord3_gui_bright, bg = nord.none, style = italic },
 		FoldColumn = { fg = nord.nord7_gui },
 		IncSearch = { fg = nord.nord6_gui, bg = nord.nord10_gui },
 		LineNr = { fg = nord.nord3_gui_bright },
 		CursorLineNr = { fg = nord.nord4_gui },
-		MatchParen = { fg = nord.nord15_gui, bg = nord.none, style = "bold" },
+		MatchParen = { fg = nord.nord15_gui, bg = nord.none, style = bold },
 		ModeMsg = { fg = nord.nord4_gui },
 		MoreMsg = { fg = nord.nord4_gui },
 		NonText = { fg = nord.nord1_gui },
@@ -114,12 +100,12 @@ theme.loadEditor = function()
 		QuickFixLine = { fg = nord.nord4_gui, bg = nord.none, style = "reverse" },
 		qfLineNr = { fg = nord.nord4_gui, bg = nord.none, style = "reverse" },
 		Search = { fg = nord.nord6_gui, bg = nord.nord10_gui },
-    Substitute = { fg = nord.nord0_gui, bg = nord.nord12_gui },
+		Substitute = { fg = nord.nord0_gui, bg = nord.nord12_gui },
 		SpecialKey = { fg = nord.nord9_gui },
-		SpellBad = { fg = nord.nord11_gui, bg = nord.none, style = "italic,undercurl" },
-		SpellCap = { fg = nord.nord7_gui, bg = nord.none, style = "italic,undercurl" },
-		SpellLocal = { fg = nord.nord8_gui, bg = nord.none, style = "italic,undercurl" },
-		SpellRare = { fg = nord.nord9_gui, bg = nord.none, style = "italic,undercurl" },
+		SpellBad = { fg = nord.nord11_gui, bg = nord.none, style = italic_undercurl },
+		SpellCap = { fg = nord.nord7_gui, bg = nord.none, style = italic_undercurl },
+		SpellLocal = { fg = nord.nord8_gui, bg = nord.none, style = italic_undercurl },
+		SpellRare = { fg = nord.nord9_gui, bg = nord.none, style = italic_undercurl },
 		StatusLine = { fg = nord.nord4_gui, bg = nord.nord2_gui },
 		StatusLineNC = { fg = nord.nord4_gui, bg = nord.nord1_gui },
 		StatusLineTerm = { fg = nord.nord4_gui, bg = nord.nord2_gui },
@@ -127,15 +113,15 @@ theme.loadEditor = function()
 		TabLineFill = { fg = nord.nord4_gui, bg = nord.none },
 		TablineSel = { fg = nord.nord1_gui, bg = nord.nord9_gui },
 		Tabline = { fg = nord.nord4_gui, bg = nord.nord1_gui },
-		Title = { fg = nord.nord14_gui, bg = nord.none, style = "bold" },
+		Title = { fg = nord.nord14_gui, bg = nord.none, style = bold },
 		Visual = { fg = nord.none, bg = nord.nord2_gui },
 		VisualNOS = { fg = nord.none, bg = nord.nord2_gui },
 		WarningMsg = { fg = nord.nord15_gui },
-		WildMenu = { fg = nord.nord12_gui, bg = nord.none, style = "bold" },
+		WildMenu = { fg = nord.nord12_gui, bg = nord.none, style = bold },
 		CursorColumn = { fg = nord.none, bg = nord.cursorlinefg },
 		CursorLine = { fg = nord.none, bg = nord.cursorlinefg },
 		ToolbarLine = { fg = nord.nord4_gui, bg = nord.nord1_gui },
-		ToolbarButton = { fg = nord.nord4_gui, bg = nord.none, style = "bold" },
+		ToolbarButton = { fg = nord.nord4_gui, bg = nord.none, style = bold },
 		NormalMode = { fg = nord.nord4_gui, bg = nord.none, style = "reverse" },
 		InsertMode = { fg = nord.nord14_gui, bg = nord.none, style = "reverse" },
 		ReplacelMode = { fg = nord.nord11_gui, bg = nord.none, style = "reverse" },
@@ -151,7 +137,7 @@ theme.loadEditor = function()
 		DashboardShortCut = { fg = nord.nord7_gui },
 		DashboardHeader = { fg = nord.nord9_gui },
 		DashboardCenter = { fg = nord.nord8_gui },
-		DashboardFooter = { fg = nord.nord14_gui, style = "italic" },
+		DashboardFooter = { fg = nord.nord14_gui, style = italic },
 
 		-- Barbar
 		BufferTabpageFill = { bg = nord.nord0_gui },
@@ -220,12 +206,12 @@ theme.loadEditor = function()
 
 	if vim.g.nord_uniform_diff_background then
 		editor.DiffAdd = { fg = nord.nord14_gui, bg = nord.nord1_gui } -- diff mode: Added line
-		editor.DiffChange = { fg = nord.nord13_gui, bg = nord.nord1_gui } --  diff mode: Changed line
+		editor.DiffChange = { fg = nord.nord13_gui, bg = nord.nord1_gui } -- diff mode: Changed line
 		editor.DiffDelete = { fg = nord.nord11_gui, bg = nord.nord1_gui } -- diff mode: Deleted line
 		editor.DiffText = { fg = nord.nord15_gui, bg = nord.nord1_gui } -- diff mode: Changed text within a changed line
 	else
 		editor.DiffAdd = { fg = nord.nord14_gui, bg = nord.none, style = "reverse" } -- diff mode: Added line
-		editor.DiffChange = { fg = nord.nord13_gui, bg = nord.none, style = "reverse" } --  diff mode: Changed line
+		editor.DiffChange = { fg = nord.nord13_gui, bg = nord.none, style = "reverse" } -- diff mode: Changed line
 		editor.DiffDelete = { fg = nord.nord11_gui, bg = nord.none, style = "reverse" } -- diff mode: Deleted line
 		editor.DiffText = { fg = nord.nord15_gui, bg = nord.none, style = "reverse" } -- diff mode: Changed text within a changed line
 	end
@@ -326,123 +312,61 @@ theme.loadTreeSitter = function()
 		-- @string.special
 	}
 
-  if vim.g.nord_bold == false then
-		treesitter.TSVariableBuiltin = { fg = nord.nord4_gui }
-		treesitter.TSBoolean = { fg = nord.nord9_gui } -- For booleans.
-		treesitter.TSConstBuiltin = { fg = nord.nord7_gui } -- For constant that are built in the language: `nil` in Lua.
-		treesitter.TSConstMacro = { fg = nord.nord7_gui } -- For constants that are defined by macros: `NULL` in C.
-		treesitter.TSVariable = { fg = nord.nord4_gui } -- Any variable name that does not have another highlight.
-		treesitter.TSTitle = { fg = nord.nord10_gui, bg = nord.none } -- Text that is part of a title.
-		treesitter["@variable"] = { fg = nord.nord4_gui }
-		treesitter["@variable.builtin"] = { fg = nord.nord4_gui }
-		treesitter["@variable.global"] = { fg = nord.nord4_gui }
-		treesitter["@boolean"] = { fg = nord.nord9_gui }
-		treesitter["@constant.builtin"] = { fg = nord.nord7_gui }
-		treesitter["@constant.macro"] = { fg = nord.nord7_gui }
-		treesitter["@text.title"] = { fg = nord.nord10_gui, bg = nord.none }
-		treesitter["@text.strong"] = { fg = nord.nord10_gui, bg = nord.none }
-  else
-		treesitter.TSVariableBuiltin = { fg = nord.nord4_gui, style = "bold" }
-		treesitter.TSBoolean = { fg = nord.nord9_gui, style = "bold" }
-		treesitter.TSConstBuiltin = { fg = nord.nord7_gui, style = "bold" }
-		treesitter.TSConstMacro = { fg = nord.nord7_gui, style = "bold" }
-		treesitter.TSVariable = { fg = nord.nord4_gui, style = "bold" }
-		treesitter.TSTitle = { fg = nord.nord10_gui, bg = nord.none, style = "bold" }
-		treesitter["@variable"] = { fg = nord.nord4_gui, style = "bold" }
-		treesitter["@variable.builtin"] = { fg = nord.nord4_gui, style = "bold" }
-		treesitter["@variable.global"] = { fg = nord.nord4_gui, style = "bold" }
-		treesitter["@boolean"] = { fg = nord.nord9_gui, style = "bold" }
-		treesitter["@constant.builtin"] = { fg = nord.nord7_gui, style = "bold" }
-		treesitter["@constant.macro"] = { fg = nord.nord7_gui, style = "bold" }
-		treesitter["@text.title"] = { fg = nord.nord10_gui, bg = nord.none, style = "bold" }
-		treesitter["@text.strong"] = { fg = nord.nord10_gui, bg = nord.none, style = "bold" }
-  end
+	treesitter.TSVariableBuiltin = { fg = nord.nord4_gui, style = bold }
+	treesitter.TSBoolean = { fg = nord.nord9_gui, style = bold }
+	treesitter.TSConstBuiltin = { fg = nord.nord7_gui, style = bold }
+	treesitter.TSConstMacro = { fg = nord.nord7_gui, style = bold }
+	treesitter.TSVariable = { fg = nord.nord4_gui, style = bold }
+	treesitter.TSTitle = { fg = nord.nord10_gui, bg = nord.none, style = bold }
+	treesitter["@variable"] = { fg = nord.nord4_gui, style = bold }
+	treesitter["@variable.builtin"] = { fg = nord.nord4_gui, style = bold }
+	treesitter["@variable.global"] = { fg = nord.nord4_gui, style = bold }
+	treesitter["@boolean"] = { fg = nord.nord9_gui, style = bold }
+	treesitter["@constant.builtin"] = { fg = nord.nord7_gui, style = bold }
+	treesitter["@constant.macro"] = { fg = nord.nord7_gui, style = bold }
+	treesitter["@text.title"] = { fg = nord.nord10_gui, bg = nord.none, style = bold }
+	treesitter["@text.strong"] = { fg = nord.nord10_gui, bg = nord.none, style = bold }
+	-- Comments
+	treesitter.TSComment = { fg = nord.nord3_gui_bright, style = italic }
+	-- Conditionals
+	treesitter.TSConditional = { fg = nord.nord9_gui, style = italic } -- For keywords related to conditionnals.
+	-- Function names
+	treesitter.TSFunction = { fg = nord.nord8_gui, style = italic } -- For fuction (calls and definitions).
+	treesitter.TSMethod = { fg = nord.nord7_gui, style = italic } -- For method calls and definitions.
+	treesitter.TSFuncBuiltin = { fg = nord.nord8_gui, style = italic }
+	-- Namespaces and property accessors
+	treesitter.TSNamespace = { fg = nord.nord4_gui, style = italic } -- For identifiers referring to modules and namespaces.
+	treesitter.TSField = { fg = nord.nord4_gui, style = italic } -- For fields.
+	treesitter.TSProperty = { fg = nord.nord10_gui, style = italic } -- Same as `TSField`, but when accessing, not declaring.
+	-- Language keywords
+	treesitter.TSKeyword = { fg = nord.nord9_gui, style = italic } -- For keywords that don't fall in other categories.
+	treesitter.TSKeywordFunction = { fg = nord.nord8_gui, style = italic }
+	treesitter.TSKeywordReturn = { fg = nord.nord8_gui, style = italic }
+	treesitter.TSKeywordOperator = { fg = nord.nord8_gui, style = italic }
+	treesitter.TSRepeat = { fg = nord.nord9_gui, style = italic } -- For keywords related to loops.
+	-- Strings
+	treesitter.TSString = { fg = nord.nord14_gui, style = italic } -- For strings.
+	treesitter.TSStringRegex = { fg = nord.nord7_gui, style = italic } -- For regexes.
+	treesitter.TSStringEscape = { fg = nord.nord15_gui, style = italic } -- For escape characters within a string.
+	treesitter.TSCharacter = { fg = nord.nord14_gui, style = italic } -- For characters.
 
-	if vim.g.nord_italic == false then
-		-- Comments
-		treesitter.TSComment = { fg = nord.nord3_gui_bright }
-		-- Conditionals
-		treesitter.TSConditional = { fg = nord.nord9_gui } -- For keywords related to conditionnals.
-		-- Function names
-		treesitter.TSFunction = { fg = nord.nord8_gui } -- For fuction (calls and definitions).
-		treesitter.TSMethod = { fg = nord.nord7_gui } -- For method calls and definitions.
-		treesitter.TSFuncBuiltin = { fg = nord.nord8_gui }
-		-- Namespaces and property accessors
-		treesitter.TSNamespace = { fg = nord.nord4_gui } -- For identifiers referring to modules and namespaces.
-		treesitter.TSField = { fg = nord.nord4_gui } -- For fields in literals
-		treesitter.TSProperty = { fg = nord.nord10_gui } -- Same as `TSField`
-		-- Language keywords
-		treesitter.TSKeyword = { fg = nord.nord9_gui } -- For keywords that don't fall in other categories.
-		treesitter.TSKeywordFunction = { fg = nord.nord8_gui }
-		treesitter.TSKeywordReturn = { fg = nord.nord8_gui }
-		treesitter.TSKeywordOperator = { fg = nord.nord8_gui }
-		treesitter.TSRepeat = { fg = nord.nord9_gui } -- For keywords related to loops.
-		-- Strings
-		treesitter.TSString = { fg = nord.nord14_gui } -- For strings.
-		treesitter.TSStringRegex = { fg = nord.nord7_gui } -- For regexes.
-		treesitter.TSStringEscape = { fg = nord.nord15_gui } -- For escape characters within a string.
-		treesitter.TSCharacter = { fg = nord.nord14_gui } -- For characters.
-
-		treesitter["@comment"] = { fg = nord.nord3_gui_bright }
-		treesitter["@conditional"] = { fg = nord.nord9_gui }
-		treesitter["@function"] = { fg = nord.nord8_gui }
-		treesitter["@method"] = { fg = nord.nord7_gui }
-		treesitter["@function.builtin"] = { fg = nord.nord8_gui }
-		treesitter["@namespace"] = { fg = nord.nord4_gui }
-		treesitter["@field"] = { fg = nord.nord4_gui }
-		treesitter["@property"] = { fg = nord.nord10_gui }
-		treesitter["@keyword"] = { fg = nord.nord9_gui }
-		treesitter["@keyword.function"] = { fg = nord.nord8_gui }
-		treesitter["@keyword.return"] = { fg = nord.nord8_gui }
-		treesitter["@keyword.operator"] = { fg = nord.nord8_gui }
-		treesitter["@repeat"] = { fg = nord.nord9_gui }
-		treesitter["@string"] = { fg = nord.nord14_gui }
-		treesitter["@string.regex"] = { fg = nord.nord7_gui }
-		treesitter["@string.escape"] = { fg = nord.nord15_gui }
-		treesitter["@character"] = { fg = nord.nord14_gui }
-	else
-		-- Comments
-		treesitter.TSComment = { fg = nord.nord3_gui_bright, style = "italic" }
-		-- Conditionals
-		treesitter.TSConditional = { fg = nord.nord9_gui, style = "italic" } -- For keywords related to conditionnals.
-		-- Function names
-		treesitter.TSFunction = { fg = nord.nord8_gui, style = "italic" } -- For fuction (calls and definitions).
-		treesitter.TSMethod = { fg = nord.nord7_gui, style = "italic" } -- For method calls and definitions.
-		treesitter.TSFuncBuiltin = { fg = nord.nord8_gui, style = "italic" }
-		-- Namespaces and property accessors
-		treesitter.TSNamespace = { fg = nord.nord4_gui, style = "italic" } -- For identifiers referring to modules and namespaces.
-		treesitter.TSField = { fg = nord.nord4_gui, style = "italic" } -- For fields.
-		treesitter.TSProperty = { fg = nord.nord10_gui, style = "italic" } -- Same as `TSField`, but when accessing, not declaring.
-		-- Language keywords
-		treesitter.TSKeyword = { fg = nord.nord9_gui, style = "italic" } -- For keywords that don't fall in other categories.
-		treesitter.TSKeywordFunction = { fg = nord.nord8_gui, style = "italic" }
-		treesitter.TSKeywordReturn = { fg = nord.nord8_gui, style = "italic" }
-		treesitter.TSKeywordOperator = { fg = nord.nord8_gui, style = "italic" }
-		treesitter.TSRepeat = { fg = nord.nord9_gui, style = "italic" } -- For keywords related to loops.
-		-- Strings
-		treesitter.TSString = { fg = nord.nord14_gui, style = "italic" } -- For strings.
-		treesitter.TSStringRegex = { fg = nord.nord7_gui, style = "italic" } -- For regexes.
-		treesitter.TSStringEscape = { fg = nord.nord15_gui, style = "italic" } -- For escape characters within a string.
-		treesitter.TSCharacter = { fg = nord.nord14_gui, style = "italic" } -- For characters.
-
-		treesitter["@comment"] = { fg = nord.nord3_gui_bright, style = "italic" }
-		treesitter["@conditional"] = { fg = nord.nord9_gui, style = "italic" }
-		treesitter["@function"] = { fg = nord.nord8_gui, style = "italic" }
-		treesitter["@method"] = { fg = nord.nord8_gui, style = "italic" }
-		treesitter["@function.builtin"] = { fg = nord.nord8_gui, style = "italic" }
-		treesitter["@namespace"] = { fg = nord.nord4_gui, style = "italic" }
-		treesitter["@field"] = { fg = nord.nord4_gui, style = "italic" }
-		treesitter["@property"] = { fg = nord.nord10_gui, style = "italic" }
-		treesitter["@keyword"] = { fg = nord.nord9_gui, style = "italic" }
-		treesitter["@keyword.function"] = { fg = nord.nord8_gui, style = "italic" }
-		treesitter["@keyword.return"] = { fg = nord.nord8_gui, style = "italic" }
-		treesitter["@keyword.operator"] = { fg = nord.nord8_gui, style = "italic" }
-		treesitter["@repeat"] = { fg = nord.nord9_gui, style = "italic" }
-		treesitter["@string"] = { fg = nord.nord14_gui, style = "italic" }
-		treesitter["@string.regex"] = { fg = nord.nord7_gui, style = "italic" }
-		treesitter["@string.escape"] = { fg = nord.nord15_gui, style = "italic" }
-		treesitter["@character"] = { fg = nord.nord14_gui, style = "italic" }
-	end
+	treesitter["@comment"] = { fg = nord.nord3_gui_bright, style = italic }
+	treesitter["@conditional"] = { fg = nord.nord9_gui, style = italic }
+	treesitter["@function"] = { fg = nord.nord8_gui, style = italic }
+	treesitter["@method"] = { fg = nord.nord8_gui, style = italic }
+	treesitter["@function.builtin"] = { fg = nord.nord8_gui, style = italic }
+	treesitter["@namespace"] = { fg = nord.nord4_gui, style = italic }
+	treesitter["@field"] = { fg = nord.nord4_gui, style = italic }
+	treesitter["@property"] = { fg = nord.nord10_gui, style = italic }
+	treesitter["@keyword"] = { fg = nord.nord9_gui, style = italic }
+	treesitter["@keyword.function"] = { fg = nord.nord8_gui, style = italic }
+	treesitter["@keyword.return"] = { fg = nord.nord8_gui, style = italic }
+	treesitter["@keyword.operator"] = { fg = nord.nord8_gui, style = italic }
+	treesitter["@repeat"] = { fg = nord.nord9_gui, style = italic }
+	treesitter["@string"] = { fg = nord.nord14_gui, style = italic }
+	treesitter["@string.regex"] = { fg = nord.nord7_gui, style = italic }
+	treesitter["@string.escape"] = { fg = nord.nord15_gui, style = italic }
+	treesitter["@character"] = { fg = nord.nord14_gui, style = italic }
 
 	return treesitter
 end
@@ -561,7 +485,7 @@ theme.loadPlugins = function()
 		GitSignsDelete = { fg = nord.nord11_gui }, -- diff mode: Deleted line |diff.txt|
 		GitSignsDeleteNr = { fg = nord.nord11_gui }, -- diff mode: Deleted line |diff.txt|
 		GitSignsDeleteLn = { fg = nord.nord11_gui }, -- diff mode: Deleted line |diff.txt|
-		GitSignsCurrentLineBlame = { fg = nord.nord3_gui_bright, style = "bold" },
+		GitSignsCurrentLineBlame = { fg = nord.nord3_gui_bright, style = bold },
 
 		-- Telescope
 		TelescopePromptBorder = { fg = nord.nord4_gui },
@@ -572,121 +496,121 @@ theme.loadPlugins = function()
 		TelescopeMatching = { link = 'Search' },
 
 		-- NvimTree
-    NvimTreeRootFolder = { fg = nord.nord15_gui },
-    NvimTreeSymlink = { fg = nord.nord5_gui },
-    NvimTreeFolderName = { fg = nord.nord4_gui },
-    NvimTreeFolderIcon = { fg = nord.nord9_gui },
-    NvimTreeEmptyFolderName = { fg = nord.nord4_gui },
-    NvimTreeOpenedFolderName = { fg = nord.nord5_gui },
-    NvimTreeExecFile = { fg = nord.nord4_gui },
-    NvimTreeOpenedFile = { fg = nord.nord6_gui },
-    NvimTreeSpecialFile = { fg = nord.nord4_gui, style = "bold"},
-    NvimTreeImageFile = { fg = nord.nord4_gui },
-    NvimTreeMarkdownFile = { fg = nord.nord4_gui },
-    NvimTreeIndentMarker = { fg = nord.nord9_gui },
-    NvimTreeGitDirty = { fg = nord.nord13_gui }, -- diff mode: Changed line |diff.txt|
-    NvimTreeGitStaged = { fg = nord.nord13_gui }, -- diff mode: Changed line |diff.txt|
-    NvimTreeGitMerge = { fg = nord.nord13_gui }, -- diff mode: Changed line |diff.txt|
-    NvimTreeGitRenamed = { fg = nord.nord13_gui }, -- diff mode: Changed line |diff.txt|
-    NvimTreeGitNew = { fg = nord.nord14_gui }, -- diff mode: Added line |diff.txt|
-    NvimTreeGitDeleted = { fg = nord.nord11_gui },  -- diff mode: Deleted line |diff.txt|
-    NvimTreeGitIgnored = { fg = nord.nord3_gui_bright },
-    LspDiagnosticsError = { fg = nord.nord12_gui },
-    LspDiagnosticsWarning = { fg = nord.nord15_gui },
-    LspDiagnosticsInformation = { fg = nord.nord10_gui },
-    LspDiagnosticsHint = { fg = nord.nord9_gui },
+		NvimTreeRootFolder = { fg = nord.nord15_gui },
+		NvimTreeSymlink = { fg = nord.nord5_gui },
+		NvimTreeFolderName = { fg = nord.nord4_gui },
+		NvimTreeFolderIcon = { fg = nord.nord9_gui },
+		NvimTreeEmptyFolderName = { fg = nord.nord4_gui },
+		NvimTreeOpenedFolderName = { fg = nord.nord5_gui },
+		NvimTreeExecFile = { fg = nord.nord4_gui },
+		NvimTreeOpenedFile = { fg = nord.nord6_gui },
+		NvimTreeSpecialFile = { fg = nord.nord4_gui, style = bold},
+		NvimTreeImageFile = { fg = nord.nord4_gui },
+		NvimTreeMarkdownFile = { fg = nord.nord4_gui },
+		NvimTreeIndentMarker = { fg = nord.nord9_gui },
+		NvimTreeGitDirty = { fg = nord.nord13_gui }, -- diff mode: Changed line |diff.txt|
+		NvimTreeGitStaged = { fg = nord.nord13_gui }, -- diff mode: Changed line |diff.txt|
+		NvimTreeGitMerge = { fg = nord.nord13_gui }, -- diff mode: Changed line |diff.txt|
+		NvimTreeGitRenamed = { fg = nord.nord13_gui }, -- diff mode: Changed line |diff.txt|
+		NvimTreeGitNew = { fg = nord.nord14_gui }, -- diff mode: Added line |diff.txt|
+		NvimTreeGitDeleted = { fg = nord.nord11_gui },	-- diff mode: Deleted line |diff.txt|
+		NvimTreeGitIgnored = { fg = nord.nord3_gui_bright },
+		LspDiagnosticsError = { fg = nord.nord12_gui },
+		LspDiagnosticsWarning = { fg = nord.nord15_gui },
+		LspDiagnosticsInformation = { fg = nord.nord10_gui },
+		LspDiagnosticsHint = { fg = nord.nord9_gui },
 
 		-- WhichKey
-		WhichKey = { fg = nord.nord8_gui, style = "bold" },
+		WhichKey = { fg = nord.nord8_gui, style = bold },
 		WhichKeyGroup = { fg = nord.nord5_gui },
-		WhichKeyDesc = { fg = nord.nord7_gui, style = "italic" },
+		WhichKeyDesc = { fg = nord.nord7_gui, style = italic },
 		WhichKeySeperator = { fg = nord.nord9_gui },
 		WhichKeyFloating = { bg = nord.nord1_gui },
 		WhichKeyFloat = { bg = nord.nord1_gui },
 		WhichKeyValue = { fg = nord.nord7_gui },
 
 		-- LspSaga
-    DiagnosticError = { fg = nord.nord12_gui },
-    DiagnosticWarning = { fg = nord.nord15_gui },
-    DiagnosticInformation = { fg = nord.nord10_gui },
-    DiagnosticHint = { fg = nord.nord9_gui },
-    DiagnosticTruncateLine = { fg = nord.nord4_gui },
-    LspFloatWinBorder = { fg = nord.nord4_gui, bg = nord.float },
-    LspSagaDefPreviewBorder = { fg = nord.nord4_gui, bg = nord.float },
-    DefinitionIcon = { fg = nord.nord7_gui },
-    TargetWord = { fg = nord.nord6_gui, style = 'bold' },
-    -- LspSaga code action
-    LspSagaCodeActionTitle = { link = 'Title' },
-    LspSagaCodeActionBorder = { fg = nord.nord4_gui, bg = nord.float },
-    LspSagaCodeActionTrunCateLine = { link = 'LspSagaCodeActionBorder' },
-    LspSagaCodeActionContent = { fg = nord.nord4_gui },
-    -- LspSag finder
-    LspSagaLspFinderBorder = { fg = nord.nord4_gui, bg = nord.float },
-    LspSagaAutoPreview = { fg = nord.nord4_gui },
-    LspSagaFinderSelection = { fg = nord.nord6_gui, bg = nord.nord2_gui },
-    TargetFileName = { fg = nord.nord4_gui },
-    FinderParam = { fg = nord.nord15_gui, bold = true },
-    FinderVirtText = { fg = nord.nord15_gui15 , bg = nord.none },
-    DefinitionsIcon = { fg = nord.nord9_gui },
-    Definitions = { fg = nord.nord15_gui, bold = true },
-    DefinitionCount = { fg = nord.nord10_gui },
-    ReferencesIcon = { fg = nord.nord9_gui },
-    References = { fg = nord.nord15_gui, bold = true },
-    ReferencesCount = { fg = nord.nord10_gui },
-    ImplementsIcon = { fg = nord.nord9_gui },
-    Implements = { fg = nord.nord15_gui, bold = true },
-    ImplementsCount = { fg = nord.nord10_gui },
-    -- LspSaga finder spinner
-    FinderSpinnerBorder = { fg = nord.nord4_gui, bg = nord.float },
-    FinderSpinnerTitle = { link = 'Title' },
-    FinderSpinner = { fg = nord.nord8_gui, bold = true },
-    FinderPreviewSearch = { link = 'Search' },
-    -- LspSaga definition
-    DefinitionBorder = { fg = nord.nord4_gui, bg = nord.float },
-    DefinitionArrow = { fg = nord.nord8_gui },
-    DefinitionSearch = { link = 'Search' },
-    DefinitionFile = { fg = nord.nord4_gui, bg = nord.float },
-    -- LspSaga hover
-    LspSagaHoverBorder = { fg = nord.nord4_gui, bg = nord.float },
-    LspSagaHoverTrunCateLine = { link = 'LspSagaHoverBorder' },
-    -- Lsp rename
-    LspSagaRenameBorder = { fg = nord.nord4_gui, bg = nord.float },
-    LspSagaRenameMatch = { fg = nord.nord6_gui, bg = nord.nord9_gui },
-    -- Lsp diagnostic
-    LspSagaDiagnosticSource = { link = 'Comment' },
-    LspSagaDiagnosticError = { link = 'DiagnosticError' },
-    LspSagaDiagnosticWarn = { link = 'DiagnosticWarn' },
-    LspSagaDiagnosticInfo = { link = 'DiagnosticInfo' },
-    LspSagaDiagnosticHint = { link = 'DiagnosticHint' },
-    LspSagaErrorTrunCateLine = { link = 'DiagnosticError' },
-    LspSagaWarnTrunCateLine = { link = 'DiagnosticWarn' },
-    LspSagaInfoTrunCateLine = { link = 'DiagnosticInfo' },
-    LspSagaHintTrunCateLine = { link = 'DiagnosticHint' },
-    LspSagaDiagnosticBorder = { fg = nord.nord4_gui, bg = nord.float },
-    LspSagaDiagnosticHeader = { fg = nord.nord4_gui },
-    DiagnosticQuickFix = { fg = nord.nord14_gui, bold = true },
-    DiagnosticMap = { fg = nord.nord15_gui },
-    DiagnosticLineCol = { fg = nord.nord4_gui },
-    LspSagaDiagnosticTruncateLine = { link = 'LspSagaDiagnosticBorder' },
-    ColInLineDiagnostic = { link = 'Comment' },
-    -- LspSaga signture help
-    LspSagaSignatureHelpBorder = { fg = nord.nord4_gui, bg = nord.float },
-    LspSagaShTrunCateLine = { link = 'LspSagaSignatureHelpBorder' },
-    -- Lspsaga lightbulb
-    LspSagaLightBulb = { link = 'DiagnosticSignHint' },
-    -- LspSaga shadow
-    SagaShadow = { fg = 'black' },
-    -- LspSaga float
-    LspSagaBorderTitle = { link = 'Title' },
-    -- LspSaga Outline
-    LSOutlinePreviewBorder = { fg = nord.nord4_gui, bg = nord.float },
-    OutlineIndentEvn = { fg = nord.nord15_gui },
-    OutlineIndentOdd = { fg = nord.nord12_gui },
-    OutlineFoldPrefix = { fg = nord.nord11_gui },
-    OutlineDetail = { fg = nord.nord4_gui },
-    -- LspSaga all floatwindow
-    LspFloatWinNormal = { fg = nord.nord4_gui, bg = nord.float },
-    -- Saga End
+		DiagnosticError = { fg = nord.nord12_gui },
+		DiagnosticWarning = { fg = nord.nord15_gui },
+		DiagnosticInformation = { fg = nord.nord10_gui },
+		DiagnosticHint = { fg = nord.nord9_gui },
+		DiagnosticTruncateLine = { fg = nord.nord4_gui },
+		LspFloatWinBorder = { fg = nord.nord4_gui, bg = nord.float },
+		LspSagaDefPreviewBorder = { fg = nord.nord4_gui, bg = nord.float },
+		DefinitionIcon = { fg = nord.nord7_gui },
+		TargetWord = { fg = nord.nord6_gui, style = 'bold' },
+		-- LspSaga code action
+		LspSagaCodeActionTitle = { link = 'Title' },
+		LspSagaCodeActionBorder = { fg = nord.nord4_gui, bg = nord.float },
+		LspSagaCodeActionTrunCateLine = { link = 'LspSagaCodeActionBorder' },
+		LspSagaCodeActionContent = { fg = nord.nord4_gui },
+		-- LspSag finder
+		LspSagaLspFinderBorder = { fg = nord.nord4_gui, bg = nord.float },
+		LspSagaAutoPreview = { fg = nord.nord4_gui },
+		LspSagaFinderSelection = { fg = nord.nord6_gui, bg = nord.nord2_gui },
+		TargetFileName = { fg = nord.nord4_gui },
+		FinderParam = { fg = nord.nord15_gui, bold = true },
+		FinderVirtText = { fg = nord.nord15_gui15 , bg = nord.none },
+		DefinitionsIcon = { fg = nord.nord9_gui },
+		Definitions = { fg = nord.nord15_gui, bold = true },
+		DefinitionCount = { fg = nord.nord10_gui },
+		ReferencesIcon = { fg = nord.nord9_gui },
+		References = { fg = nord.nord15_gui, bold = true },
+		ReferencesCount = { fg = nord.nord10_gui },
+		ImplementsIcon = { fg = nord.nord9_gui },
+		Implements = { fg = nord.nord15_gui, bold = true },
+		ImplementsCount = { fg = nord.nord10_gui },
+		-- LspSaga finder spinner
+		FinderSpinnerBorder = { fg = nord.nord4_gui, bg = nord.float },
+		FinderSpinnerTitle = { link = 'Title' },
+		FinderSpinner = { fg = nord.nord8_gui, bold = true },
+		FinderPreviewSearch = { link = 'Search' },
+		-- LspSaga definition
+		DefinitionBorder = { fg = nord.nord4_gui, bg = nord.float },
+		DefinitionArrow = { fg = nord.nord8_gui },
+		DefinitionSearch = { link = 'Search' },
+		DefinitionFile = { fg = nord.nord4_gui, bg = nord.float },
+		-- LspSaga hover
+		LspSagaHoverBorder = { fg = nord.nord4_gui, bg = nord.float },
+		LspSagaHoverTrunCateLine = { link = 'LspSagaHoverBorder' },
+		-- Lsp rename
+		LspSagaRenameBorder = { fg = nord.nord4_gui, bg = nord.float },
+		LspSagaRenameMatch = { fg = nord.nord6_gui, bg = nord.nord9_gui },
+		-- Lsp diagnostic
+		LspSagaDiagnosticSource = { link = 'Comment' },
+		LspSagaDiagnosticError = { link = 'DiagnosticError' },
+		LspSagaDiagnosticWarn = { link = 'DiagnosticWarn' },
+		LspSagaDiagnosticInfo = { link = 'DiagnosticInfo' },
+		LspSagaDiagnosticHint = { link = 'DiagnosticHint' },
+		LspSagaErrorTrunCateLine = { link = 'DiagnosticError' },
+		LspSagaWarnTrunCateLine = { link = 'DiagnosticWarn' },
+		LspSagaInfoTrunCateLine = { link = 'DiagnosticInfo' },
+		LspSagaHintTrunCateLine = { link = 'DiagnosticHint' },
+		LspSagaDiagnosticBorder = { fg = nord.nord4_gui, bg = nord.float },
+		LspSagaDiagnosticHeader = { fg = nord.nord4_gui },
+		DiagnosticQuickFix = { fg = nord.nord14_gui, bold = true },
+		DiagnosticMap = { fg = nord.nord15_gui },
+		DiagnosticLineCol = { fg = nord.nord4_gui },
+		LspSagaDiagnosticTruncateLine = { link = 'LspSagaDiagnosticBorder' },
+		ColInLineDiagnostic = { link = 'Comment' },
+		-- LspSaga signture help
+		LspSagaSignatureHelpBorder = { fg = nord.nord4_gui, bg = nord.float },
+		LspSagaShTrunCateLine = { link = 'LspSagaSignatureHelpBorder' },
+		-- Lspsaga lightbulb
+		LspSagaLightBulb = { link = 'DiagnosticSignHint' },
+		-- LspSaga shadow
+		SagaShadow = { fg = 'black' },
+		-- LspSaga float
+		LspSagaBorderTitle = { link = 'Title' },
+		-- LspSaga Outline
+		LSOutlinePreviewBorder = { fg = nord.nord4_gui, bg = nord.float },
+		OutlineIndentEvn = { fg = nord.nord15_gui },
+		OutlineIndentOdd = { fg = nord.nord12_gui },
+		OutlineFoldPrefix = { fg = nord.nord11_gui },
+		OutlineDetail = { fg = nord.nord4_gui },
+		-- LspSaga all floatwindow
+		LspFloatWinNormal = { fg = nord.nord4_gui, bg = nord.float },
+		-- Saga End
 
 		-- Sneak
 		Sneak = { fg = nord.nord0_gui, bg = nord.nord4_gui },
@@ -694,8 +618,8 @@ theme.loadPlugins = function()
 
 		-- Cmp
 		CmpItemKind = { fg = nord.nord15_gui },
-		CmpItemAbbrMatch = { fg = nord.nord5_gui, style = "bold" },
-		CmpItemAbbrMatchFuzzy = { fg = nord.nord5_gui, style = "bold" },
+		CmpItemAbbrMatch = { fg = nord.nord5_gui, style = bold },
+		CmpItemAbbrMatchFuzzy = { fg = nord.nord5_gui, style = bold },
 		CmpItemAbbr = { fg = nord.nord4_gui },
 		CmpItemMenu = { fg = nord.nord14_gui },
 
@@ -749,8 +673,8 @@ theme.loadPlugins = function()
 		DapUIBreakpointsLine = { fg = nord.nord8_gui },
 
 		-- Hop
-		HopNextKey = { fg = nord.nord4_gui, style = "bold" },
-		HopNextKey1 = { fg = nord.nord8_gui, style = "bold" },
+		HopNextKey = { fg = nord.nord4_gui, style = bold },
+		HopNextKey1 = { fg = nord.nord8_gui, style = bold },
 		HopNextKey2 = { fg = nord.nord4_gui },
 		HopUnmatched = { fg = nord.nord3_gui },
 
@@ -767,13 +691,13 @@ theme.loadPlugins = function()
 		rainbowcol7 = { fg = nord.nord13_gui },
 
 		-- lightspeed
-		LightspeedLabel = { fg = nord.nord8_gui, style = "bold" },
+		LightspeedLabel = { fg = nord.nord8_gui, style = bold },
 		LightspeedLabelOverlapped = { fg = nord.nord8_gui, style = "bold,underline" },
-		LightspeedLabelDistant = { fg = nord.nord15_gui, style = "bold" },
+		LightspeedLabelDistant = { fg = nord.nord15_gui, style = bold },
 		LightspeedLabelDistantOverlapped = { fg = nord.nord15_gui, style = "bold,underline" },
-		LightspeedShortcut = { fg = nord.nord10_gui, style = "bold" },
+		LightspeedShortcut = { fg = nord.nord10_gui, style = bold },
 		LightspeedShortcutOverlapped = { fg = nord.nord10_gui, style = "bold,underline" },
-		LightspeedMaskedChar = { fg = nord.nord4_gui, bg = nord.nord2_gui, style = "bold" },
+		LightspeedMaskedChar = { fg = nord.nord4_gui, bg = nord.nord2_gui, style = bold },
 		LightspeedGreyWash = { fg = nord.nord3_gui_bright },
 		LightspeedUnlabeledMatch = { fg = nord.nord4_gui, bg = nord.nord1_gui },
 		LightspeedOneCharMatch = { fg = nord.nord8_gui, style = "bold,reverse" },
@@ -800,7 +724,7 @@ theme.loadPlugins = function()
 		MiniJump2dSpot = { fg = nord.nord12_gui, style = "bold,nocombine" },
 
 		MiniStarterCurrent = { style = "nocombine" },
-		MiniStarterFooter = { fg = nord.nord14_gui, style = "italic" },
+		MiniStarterFooter = { fg = nord.nord14_gui, style = italic },
 		MiniStarterHeader = { fg = nord.nord9_gui },
 		MiniStarterInactive = { link = "Comment" },
 		MiniStarterItem = { link = "Normal" },
@@ -812,13 +736,13 @@ theme.loadPlugins = function()
 		MiniStatuslineDevinfo = { fg = nord.nord4_gui, bg = nord.nord2_gui },
 		MiniStatuslineFileinfo = { fg = nord.nord4_gui, bg = nord.nord2_gui },
 		MiniStatuslineFilename = { fg = nord.nord4_gui, bg = nord.nord1_gui },
-		MiniStatuslineInactive = { fg = nord.nord4_gui, bg = nord.nord0_gui, style = "bold" },
-		MiniStatuslineModeCommand = { fg = nord.nord0_gui, bg = nord.nord15_gui, style = "bold" },
-		MiniStatuslineModeInsert = { fg = nord.nord1_gui, bg = nord.nord4_gui, style = "bold" },
-		MiniStatuslineModeNormal = { fg = nord.nord1_gui, bg = nord.nord9_gui, style = "bold" },
-		MiniStatuslineModeOther = { fg = nord.nord0_gui, bg = nord.nord13_gui, style = "bold" },
-		MiniStatuslineModeReplace = { fg = nord.nord0_gui, bg = nord.nord11_gui, style = "bold" },
-		MiniStatuslineModeVisual = { fg = nord.nord0_gui, bg = nord.nord7_gui, style = "bold" },
+		MiniStatuslineInactive = { fg = nord.nord4_gui, bg = nord.nord0_gui, style = bold },
+		MiniStatuslineModeCommand = { fg = nord.nord0_gui, bg = nord.nord15_gui, style = bold },
+		MiniStatuslineModeInsert = { fg = nord.nord1_gui, bg = nord.nord4_gui, style = bold },
+		MiniStatuslineModeNormal = { fg = nord.nord1_gui, bg = nord.nord9_gui, style = bold },
+		MiniStatuslineModeOther = { fg = nord.nord0_gui, bg = nord.nord13_gui, style = bold },
+		MiniStatuslineModeReplace = { fg = nord.nord0_gui, bg = nord.nord11_gui, style = bold },
+		MiniStatuslineModeVisual = { fg = nord.nord0_gui, bg = nord.nord7_gui, style = bold },
 
 		MiniSurround = { link = "IncSearch" },
 
@@ -828,12 +752,12 @@ theme.loadPlugins = function()
 		MiniTablineModifiedCurrent = { bg = nord.nord1_gui, fg = nord.nord15_gui },
 		MiniTablineModifiedHidden = { bg = nord.nord0_gui, fg = nord.nord15_gui },
 		MiniTablineModifiedVisible = { bg = nord.nord2_gui, fg = nord.nord15_gui },
-		MiniTablineTabpagesection = { fg = nord.nord10_gui, bg = nord.nord6_gui, style = "reverse,bold" },
+		MiniTablineTabpagesection = { fg = nord.nord10_gui, bg = nord.nord6_gui, style = reverse_bold },
 		MiniTablineVisible = { bg = nord.nord2_gui },
 
-		MiniTestEmphasis = { style = "bold" },
-		MiniTestFail = { fg = nord.nord11_gui, style = "bold" },
-		MiniTestPass = { fg = nord.nord14_gui, style = "bold" },
+		MiniTestEmphasis = { style = bold },
+		MiniTestFail = { fg = nord.nord11_gui, style = bold },
+		MiniTestPass = { fg = nord.nord14_gui, style = bold },
 
 		MiniTrailspace = { bg = nord.nord11_gui },
 
@@ -842,90 +766,88 @@ theme.loadPlugins = function()
 		AerialLineNC = { bg = nord.nord2_gui },
 
 		AerialArrayIcon = { fg = nord.nord13_gui },
-		AerialBooleanIcon = { fg = nord.nord9_gui, style = "bold" },
+		AerialBooleanIcon = { fg = nord.nord9_gui, style = bold },
 		AerialClassIcon = { fg = nord.nord9_gui },
 		AerialConstantIcon = { fg = nord.nord13_gui },
 		AerialConstructorIcon = { fg = nord.nord9_gui },
 		AerialEnumIcon = { fg = nord.nord9_gui },
 		AerialEnumMemberIcon = { fg = nord.nord4_gui },
 		AerialEventIcon = { fg = nord.nord9_gui },
-		AerialFieldIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
+		AerialFieldIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic } or { fg = nord.nord4_gui },
 		AerialFileIcon = { fg = nord.nord14_gui },
-		AerialFunctionIcon = vim.g.nord_italic and { fg = nord.nord8_gui, style = "italic" } or { fg = nord.nord8_gui },
+		AerialFunctionIcon = vim.g.nord_italic and { fg = nord.nord8_gui, style = italic } or { fg = nord.nord8_gui },
 		AerialInterfaceIcon = { fg = nord.nord9_gui },
 		AerialKeyIcon = { fg = nord.nord9_gui },
-		AerialMethodIcon = vim.g.nord_italic and { fg = nord.nord7_gui, style = "italic" } or { fg = nord.nord7_gui },
-		AerialModuleIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
-		AerialNamespaceIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" }
+		AerialMethodIcon = vim.g.nord_italic and { fg = nord.nord7_gui, style = italic } or { fg = nord.nord7_gui },
+		AerialModuleIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic } or { fg = nord.nord4_gui },
+		AerialNamespaceIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic }
 			or { fg = nord.nord4_gui },
 		AerialNullIcon = { fg = nord.nord9_gui },
 		AerialNumberIcon = { fg = nord.nord15_gui },
 		AerialObjectIcon = { fg = nord.nord9_gui },
 		AerialOperatorIcon = { fg = nord.nord9_gui },
-		AerialPackageIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
-		AerialPropertyIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" }
+		AerialPackageIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic } or { fg = nord.nord4_gui },
+		AerialPropertyIcon = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic }
 			or { fg = nord.nord10_gui },
-		AerialStringIcon = vim.g.nord_italic and { fg = nord.nord14_gui, style = "italic" } or { fg = nord.nord14_gui },
+		AerialStringIcon = vim.g.nord_italic and { fg = nord.nord14_gui, style = italic } or { fg = nord.nord14_gui },
 		AerialStructIcon = { fg = nord.nord9_gui },
 		AerialTypeParameterIcon = { fg = nord.nord10_gui },
-		AerialVariableIcon = { fg = nord.nord4_gui, style = "bold" },
+		AerialVariableIcon = { fg = nord.nord4_gui, style = bold },
 
 		AerialArray = { fg = nord.nord13_gui },
-		AerialBoolean = { fg = nord.nord9_gui, style = "bold" },
+		AerialBoolean = { fg = nord.nord9_gui, style = bold },
 		AerialClass = { fg = nord.nord9_gui },
 		AerialConstant = { fg = nord.nord13_gui },
 		AerialConstructor = { fg = nord.nord9_gui },
 		AerialEnum = { fg = nord.nord9_gui },
 		AerialEnumMember = { fg = nord.nord4_gui },
 		AerialEvent = { fg = nord.nord9_gui },
-		AerialField = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
+		AerialField = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic } or { fg = nord.nord4_gui },
 		AerialFile = { fg = nord.nord14_gui },
-		AerialFunction = vim.g.nord_italic and { fg = nord.nord8_gui, style = "italic" } or { fg = nord.nord8_gui },
+		AerialFunction = vim.g.nord_italic and { fg = nord.nord8_gui, style = italic } or { fg = nord.nord8_gui },
 		AerialInterface = { fg = nord.nord9_gui },
 		AerialKey = { fg = nord.nord9_gui },
-		AerialMethod = vim.g.nord_italic and { fg = nord.nord7_gui, style = "italic" } or { fg = nord.nord7_gui },
-		AerialModule = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
-		AerialNamespace = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
+		AerialMethod = vim.g.nord_italic and { fg = nord.nord7_gui, style = italic } or { fg = nord.nord7_gui },
+		AerialModule = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic } or { fg = nord.nord4_gui },
+		AerialNamespace = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic } or { fg = nord.nord4_gui },
 		AerialNull = { fg = nord.nord9_gui },
 		AerialNumber = { fg = nord.nord15_gui },
 		AerialObject = { fg = nord.nord9_gui },
 		AerialOperator = { fg = nord.nord9_gui },
-		AerialPackage = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
-		AerialProperty = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord10_gui },
-		AerialString = vim.g.nord_italic and { fg = nord.nord14_gui, style = "italic" } or { fg = nord.nord14_gui },
+		AerialPackage = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic } or { fg = nord.nord4_gui },
+		AerialProperty = vim.g.nord_italic and { fg = nord.nord4_gui, style = italic } or { fg = nord.nord10_gui },
+		AerialString = vim.g.nord_italic and { fg = nord.nord14_gui, style = italic } or { fg = nord.nord14_gui },
 		AerialStruct = { fg = nord.nord9_gui },
 		AerialTypeParameter = { fg = nord.nord10_gui },
-		AerialVariable = { fg = nord.nord4_gui, style = "bold" },
+		AerialVariable = { fg = nord.nord4_gui, style = bold },
 
 		-- nvim-navic
 		NavicIconsArray = { fg = nord.nord13_gui },
-		NavicIconsBoolean = { fg = nord.nord9_gui, style = "bold" },
+		NavicIconsBoolean = { fg = nord.nord9_gui, style = bold },
 		NavicIconsClass = { fg = nord.nord9_gui },
 		NavicIconsConstant = { fg = nord.nord13_gui },
 		NavicIconsConstructor = { fg = nord.nord9_gui },
 		NavicIconsEnum = { fg = nord.nord9_gui },
 		NavicIconsEnumMember = { fg = nord.nord4_gui },
 		NavicIconsEvent = { fg = nord.nord9_gui },
-		NavicIconsField = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
+		NavicIconsField = { fg = nord.nord4_gui, style = italic },
 		NavicIconsFile = { fg = nord.nord14_gui },
-		NavicIconsFunction = vim.g.nord_italic and { fg = nord.nord8_gui, style = "italic" } or { fg = nord.nord8_gui },
+		NavicIconsFunction = { fg = nord.nord8_gui, style = italic },
 		NavicIconsInterface = { fg = nord.nord9_gui },
 		NavicIconsKey = { fg = nord.nord9_gui },
-		NavicIconsMethod = vim.g.nord_italic and { fg = nord.nord7_gui, style = "italic" } or { fg = nord.nord7_gui },
-		NavicIconsModule = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
-		NavicIconsNamespace = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" }
-			or { fg = nord.nord4_gui },
+		NavicIconsMethod = { fg = nord.nord7_gui, style = italic },
+		NavicIconsModule = { fg = nord.nord4_gui, style = italic },
+		NavicIconsNamespace = { fg = nord.nord4_gui, style = italic },
 		NavicIconsNull = { fg = nord.nord9_gui },
 		NavicIconsNumber = { fg = nord.nord15_gui },
 		NavicIconsObject = { fg = nord.nord9_gui },
 		NavicIconsOperator = { fg = nord.nord9_gui },
-		NavicIconsPackage = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" } or { fg = nord.nord4_gui },
-		NavicIconsProperty = vim.g.nord_italic and { fg = nord.nord4_gui, style = "italic" }
-			or { fg = nord.nord10_gui },
-		NavicIconsString = vim.g.nord_italic and { fg = nord.nord14_gui, style = "italic" } or { fg = nord.nord14_gui },
+		NavicIconsPackage = { fg = nord.nord4_gui, style = italic },
+		NavicIconsProperty = { fg = nord.nord4_gui, style = italic },
+		NavicIconsString = { fg = nord.nord14_gui, style = italic },
 		NavicIconsStruct = { fg = nord.nord9_gui },
 		NavicIconsTypeParameter = { fg = nord.nord10_gui },
-		NavicIconsVariable = { fg = nord.nord4_gui, style = "bold" },
+		NavicIconsVariable = { fg = nord.nord4_gui, style = bold },
 		NavicText = { fg = nord.nord4_gui },
 		NavicSeparator = { fg = nord.nord4_gui },
 	}


### PR DESCRIPTION
I noticed that nord_italic wasn't being correctly respected in spell colors. Tweaked the code to do this a bit more consistently (also, less code).