### PR TITLE
Handling error

### DIFF
--- a/doc/nord.txt
+++ b/doc/nord.txt
@@ -70,5 +70,8 @@ CONTENTS
         }~
     Just make sure to set the theme to "nord", as "nord" already
     exist built in to lualine
+    
+    If the lualine's background has become transparent, make sure that
+    lualine setup is being called after the nord theme has been applied.
 
 vim:tw=78:ts=4:ft=help:norl:


### PR DESCRIPTION
I had this problem and it took me a while to resolve it. When the 'hi clear' command is used in a nord theme function, it makes the Lualine's background disappear. After I found that, I made the lualine file be called only after nord.nvim had already run. For this reason, I think this warning is important, because there may be several people who will experience the same error.