### PR TITLE
WinBar highlights

### DIFF
--- a/lua/nord/theme.lua
+++ b/lua/nord/theme.lua
@@ -106,6 +106,8 @@ theme.loadEditor = function()
 		SpellCap = { fg = nord.nord7_gui, bg = nord.none, style = italic_undercurl },
 		SpellLocal = { fg = nord.nord8_gui, bg = nord.none, style = italic_undercurl },
 		SpellRare = { fg = nord.nord9_gui, bg = nord.none, style = italic_undercurl },
+		WinBar = { fg = nord.nord4_gui, bg = nord.nord2_gui },
+		WinBarNC  = { fg = nord.nord4_gui, bg = nord.nord1_gui },
 		StatusLine = { fg = nord.nord4_gui, bg = nord.nord2_gui },
 		StatusLineNC = { fg = nord.nord4_gui, bg = nord.nord1_gui },
 		StatusLineTerm = { fg = nord.nord4_gui, bg = nord.nord2_gui },


### PR DESCRIPTION
Add WinBar and WinBarNC highlights, matching the existing ones for StatusLine and StatusLineNC 

Without this highlight group the WinBar takes the default black, which looks kinda bad with Nord

<img width="912" alt="image" src="https://github.com/user-attachments/assets/23cc9b5b-e2d3-4f43-bf9b-f93d87590c87">

With my change it looks like this

<img width="909" alt="image" src="https://github.com/user-attachments/assets/e9475b55-5cad-4e34-af26-e4de3801963a">

